### PR TITLE
Cache services

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = 'com.imsweb'
-version = '3.2'
+version = '3.3'
 description = 'Java client library for SEER*API'
 
 println "Starting build using ${Jvm.current()}"

--- a/src/main/java/com/imsweb/seerapi/client/SeerApi.java
+++ b/src/main/java/com/imsweb/seerapi/client/SeerApi.java
@@ -35,8 +35,6 @@ import com.imsweb.seerapi.client.surgery.SurgeryService;
  */
 public final class SeerApi {
 
-    private Retrofit _retrofit;
-
     private DiseaseService _diseaseService;
     private GlossaryService _glossaryService;
     private NaaccrService _naaccrService;
@@ -71,21 +69,21 @@ public final class SeerApi {
                 .addInterceptor(new ErrorInterceptor())
                 .build();
 
-        _retrofit = new Retrofit.Builder()
+        Retrofit retrofit = new Retrofit.Builder()
                 .baseUrl(baseUrl)
                 .addConverterFactory(JacksonConverterFactory.create(getMapper()))
                 .client(client)
                 .build();
 
         // create cached service entities
-        _diseaseService = _retrofit.create(DiseaseService.class);
-        _glossaryService = _retrofit.create(GlossaryService.class);
-        _naaccrService = _retrofit.create(NaaccrService.class);
-        _ndcService = _retrofit.create(NdcService.class);
-        _rxService = _retrofit.create(RxService.class);
-        _siteRecodeService = _retrofit.create(SiteRecodeService.class);
-        _stagingService = _retrofit.create(StagingService.class);
-        _surgeryService = _retrofit.create(SurgeryService.class);
+        _diseaseService = retrofit.create(DiseaseService.class);
+        _glossaryService = retrofit.create(GlossaryService.class);
+        _naaccrService = retrofit.create(NaaccrService.class);
+        _ndcService = retrofit.create(NdcService.class);
+        _rxService = retrofit.create(RxService.class);
+        _siteRecodeService = retrofit.create(SiteRecodeService.class);
+        _stagingService = retrofit.create(StagingService.class);
+        _surgeryService = retrofit.create(SurgeryService.class);
     }
 
     /**

--- a/src/main/java/com/imsweb/seerapi/client/SeerApi.java
+++ b/src/main/java/com/imsweb/seerapi/client/SeerApi.java
@@ -37,6 +37,15 @@ public final class SeerApi {
 
     private Retrofit _retrofit;
 
+    private DiseaseService _diseaseService;
+    private GlossaryService _glossaryService;
+    private NaaccrService _naaccrService;
+    private NdcService _ndcService;
+    private RxService _rxService;
+    private SiteRecodeService _siteRecodeService;
+    private StagingService _stagingService;
+    private SurgeryService _surgeryService;
+
     /**
      * Creates a client API root object
      * @param baseUrl base URL for API
@@ -67,6 +76,16 @@ public final class SeerApi {
                 .addConverterFactory(JacksonConverterFactory.create(getMapper()))
                 .client(client)
                 .build();
+
+        // create cached service entities
+        _diseaseService = _retrofit.create(DiseaseService.class);
+        _glossaryService = _retrofit.create(GlossaryService.class);
+        _naaccrService = _retrofit.create(NaaccrService.class);
+        _ndcService = _retrofit.create(NdcService.class);
+        _rxService = _retrofit.create(RxService.class);
+        _siteRecodeService = _retrofit.create(SiteRecodeService.class);
+        _stagingService = _retrofit.create(StagingService.class);
+        _surgeryService = _retrofit.create(SurgeryService.class);
     }
 
     /**
@@ -97,7 +116,7 @@ public final class SeerApi {
      * @return an interface to all the disease APIs
      */
     public DiseaseService disease() {
-        return _retrofit.create(DiseaseService.class);
+        return _diseaseService;
     }
 
     /**
@@ -105,7 +124,7 @@ public final class SeerApi {
      * @return an interface to all the glossary APIs
      */
     public GlossaryService glossary() {
-        return _retrofit.create(GlossaryService.class);
+        return _glossaryService;
     }
 
     /**
@@ -113,7 +132,7 @@ public final class SeerApi {
      * @return an inteface to all the NAACCR APIs
      */
     public NaaccrService naaccr() {
-        return _retrofit.create(NaaccrService.class);
+        return _naaccrService;
     }
 
     /**
@@ -121,7 +140,7 @@ public final class SeerApi {
      * @return an inteface to all the NDC APIs
      */
     public NdcService ndc() {
-        return _retrofit.create(NdcService.class);
+        return _ndcService;
     }
 
     /**
@@ -129,7 +148,7 @@ public final class SeerApi {
      * @return an inteface to all the Rx APIs
      */
     public RxService rx() {
-        return _retrofit.create(RxService.class);
+        return _rxService;
     }
 
     /**
@@ -137,7 +156,7 @@ public final class SeerApi {
      * @return an interface to all the site recode APIs
      */
     public SiteRecodeService siteRecode() {
-        return _retrofit.create(SiteRecodeService.class);
+        return _siteRecodeService;
     }
 
     /**
@@ -145,7 +164,7 @@ public final class SeerApi {
      * @return an interface to all the staging APIs
      */
     public StagingService staging() {
-        return _retrofit.create(StagingService.class);
+        return _stagingService;
     }
 
     /**
@@ -153,7 +172,7 @@ public final class SeerApi {
      * @return an interface to all the surgery APIs
      */
     public SurgeryService surgery() {
-        return _retrofit.create(SurgeryService.class);
+        return _surgeryService;
     }
 
     /**


### PR DESCRIPTION
In some rare cases, recreating the services could cause a memory leak.  To be safe, create the services once and return cached instances of them.