### PR TITLE
Fixed MPH and added metadata to staging output

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 plugins {
     id 'java-library'
     id 'checkstyle'
-    id "com.github.spotbugs" version "4.5.1"
+    id "com.github.spotbugs" version "4.7.0"
     id 'maven-publish'
     id 'signing'
-    id "io.codearte.nexus-staging" version "0.22.0"
-    id 'com.adarshr.test-logger' version '2.1.1'
-    id "com.github.ben-manes.versions" version "0.36.0"
-    id 'org.sonatype.gradle.plugins.scan' version '2.0.3'
+    id "io.codearte.nexus-staging" version "0.30.0"
+    id 'com.adarshr.test-logger' version '3.0.0'
+    id "com.github.ben-manes.versions" version "0.38.0"
+    id 'org.sonatype.gradle.plugins.scan' version '2.0.7'
 }
 
 group = 'com.imsweb'
@@ -32,7 +32,7 @@ repositories {
 }
 
 dependencies {
-    spotbugs 'com.github.spotbugs:spotbugs:4.2.1'
+    spotbugs 'com.github.spotbugs:spotbugs:4.2.3'
 
     api 'com.squareup.retrofit2:retrofit:2.9.0'
     api 'com.squareup.retrofit2:converter-jackson:2.9.0'
@@ -87,7 +87,7 @@ ossIndexAudit {
 check.dependsOn 'ossIndexAudit'
 
 wrapper {
-    gradleVersion = '6.8.2'
+    gradleVersion = '7.0'
     distributionType = Wrapper.DistributionType.ALL
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/imsweb/seerapi/client/mph/MphService.java
+++ b/src/main/java/com/imsweb/seerapi/client/mph/MphService.java
@@ -6,27 +6,15 @@ package com.imsweb.seerapi.client.mph;
 import retrofit2.Call;
 import retrofit2.http.Body;
 import retrofit2.http.POST;
-import retrofit2.http.Query;
-
-import com.imsweb.seerapi.client.mph.MphInput.HistologyMatchMode;
 
 public interface MphService {
 
     /**
-     * Uses multiple primary rules to compare two diseases using strict histology matching mode
+     * Uses multiple primary rules to compare two diseases
      * @param pair a pair of diseases
      * @return a result indicating whether the two diseases are the same primary
      */
     @POST("mph")
     Call<MphOutput> mph(@Body MphInputPair pair);
-
-    /**
-     * Uses multiple primary rules to compare two diseases
-     * @param pair a pair of diseases
-     * @param matchMode match mode
-     * @return a result indicating whether the two diseases are the same primary
-     */
-    @POST("mph")
-    Call<MphOutput> mph(@Body MphInputPair pair, @Query("histology-matching-mode") HistologyMatchMode matchMode);
 
 }

--- a/src/main/java/com/imsweb/seerapi/client/staging/StagingSchemaOutput.java
+++ b/src/main/java/com/imsweb/seerapi/client/staging/StagingSchemaOutput.java
@@ -3,10 +3,15 @@
  */
 package com.imsweb.seerapi.client.staging;
 
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
-@JsonPropertyOrder({"key", "name", "description", "naaccr_item", "naaccr_xml_id", "table"})
+@JsonPropertyOrder({"key", "name", "description", "naaccr_item", "naaccr_xml_id", "table", "default", "metadata"})
 public class StagingSchemaOutput {
 
     private String _key;
@@ -16,6 +21,7 @@ public class StagingSchemaOutput {
     private String _naaccrXmlId;
     private String _table;
     private String _default;
+    private Set<String> _metadata;
 
     /**
      * Morphia requires a default constructor
@@ -46,6 +52,8 @@ public class StagingSchemaOutput {
         setNaaccrXmlId(other.getNaaccrXmlId());
         setTable(other.getTable());
         setDefault(other.getDefault());
+        if (other.getMetadata() != null)
+            setMetadata(new HashSet<>(other.getMetadata()));
     }
 
     @JsonProperty("key")
@@ -109,6 +117,16 @@ public class StagingSchemaOutput {
 
     public void setDefault(String aDefault) {
         _default = aDefault;
+    }
+
+    @JsonProperty("metadata")
+    public Set<String> getMetadata() {
+        return _metadata;
+    }
+
+    @JsonDeserialize(as = LinkedHashSet.class)
+    public void setMetadata(Set<String> metadata) {
+        _metadata = metadata;
     }
 
 }

--- a/src/test/java/com/imsweb/seerapi/client/mph/MphTest.java
+++ b/src/test/java/com/imsweb/seerapi/client/mph/MphTest.java
@@ -7,7 +7,6 @@ import org.junit.Test;
 
 import com.imsweb.seerapi.client.BadRequestException;
 import com.imsweb.seerapi.client.SeerApi;
-import com.imsweb.seerapi.client.mph.MphInput.HistologyMatchMode;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -125,18 +124,6 @@ public class MphTest {
         assertEquals(9, result.getAppliedRules().size());
         assertEquals(MphOutput.Result.MULTIPLE_PRIMARIES, result.getResult());
         assertEquals("M12", result.getStep());
-
-        // specify STRICT
-        result = _MPH.mph(new MphInputPair(input1, input2), HistologyMatchMode.STRICT).execute().body();
-        assertEquals(9, result.getAppliedRules().size());
-        assertEquals(MphOutput.Result.MULTIPLE_PRIMARIES, result.getResult());
-        assertEquals("M12", result.getStep());
-
-        // specify LENIENT
-        result = _MPH.mph(new MphInputPair(input1, input2), HistologyMatchMode.LENIENT).execute().body();
-        assertEquals(10, result.getAppliedRules().size());
-        assertEquals(MphOutput.Result.SINGLE_PRIMARY, result.getResult());
-        assertEquals("M13", result.getStep());
     }
 
     @Test(expected = BadRequestException.class)

--- a/src/test/java/com/imsweb/seerapi/client/rx/RxTest.java
+++ b/src/test/java/com/imsweb/seerapi/client/rx/RxTest.java
@@ -107,8 +107,8 @@ public class RxTest {
 
         assertNotNull(results);
         assertEquals(25, results.getCount().longValue());
-        assertEquals(10, results.getTotal().longValue());
-        assertEquals(10, results.getResults().size());
+        assertEquals(11, results.getTotal().longValue());
+        assertEquals(11, results.getResults().size());
         assertEquals(Collections.singletonList("abt"), results.getTerms());
 
         search.setMode(PublishableSearch.SearchMode.OR);

--- a/src/test/java/com/imsweb/seerapi/client/siterecode/SiteRecodeTest.java
+++ b/src/test/java/com/imsweb/seerapi/client/siterecode/SiteRecodeTest.java
@@ -45,7 +45,7 @@ public class SiteRecodeTest {
 
         // the API call works out to:
         //     https://api.seer.cancer.gov/rest/recode/sitegroup?site=C379
-        assertEquals("Required String parameter 'hist' is not present", message);
+        assertEquals("Required request parameter 'hist' for method parameter type String is not present", message);
     }
 
     @Test


### PR DESCRIPTION
- MPH no longer supports modes; all matching is strict
- `StagingSchemaOutput` adds metadata support