### PR TITLE
Convert to Maven Central Portal

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
-          java-version: '17'
+          java-version: '21'
       - name: Cache Gradle packages
         uses: actions/cache@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,13 +20,13 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
-          java-version: '17'
-      - name: Publish
+          java-version: '21'
+      - name: Publish to Maven Central (Portal)
         run: |
           chmod +x gradlew
-          ./gradlew publish closeAndReleaseRepository
+          ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache
         env:
-          ORG_GRADLE_PROJECT_nexusUsername: ${{ secrets.NEXUS_USERNAME }}
-          ORG_GRADLE_PROJECT_nexusPassword: ${{ secrets.NEXUS_PASSWORD }}
-          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SEER_GPG_SECRET_KEY }}
-          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SEER_GPG_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,11 @@ group = 'com.imsweb'
 version = '5.8-SNAPSHOT'
 description = 'Java client library for SEER*API'
 
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8'
+    options.compilerArgs << "-Werror" << "-Xlint:-options"
+}
+
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
@@ -32,6 +37,8 @@ dependencies {
 
     api 'com.squareup.retrofit2:retrofit:2.11.0'
     api 'com.squareup.retrofit2:converter-jackson:2.11.0'
+
+    // retrofit will not update these dependencies to fix vulnerabilities
     api 'com.squareup.okhttp3:okhttp:4.12.0'
     api 'com.squareup.okio:okio:3.11.0'
 
@@ -46,10 +53,11 @@ dependencies {
 }
 
 jar {
+    // specify the archive name; otherwise the version is appended to the war file
     archiveFileName = 'seerapi-java.jar'
+
     manifest {
-        attributes(
-                'Implementation-Title': 'SEER*API Java Client',
+        attributes('Implementation-Title': 'SEER*API Java Client',
                 'Implementation-Version': archiveVersion,
                 'Implementation-Vendor': group,
                 'Created-By': System.properties['java.vm.version'] + " (" + System.properties['java.vm.vendor'] + ")",

--- a/build.gradle
+++ b/build.gradle
@@ -1,32 +1,26 @@
+import com.vanniktech.maven.publish.JavaLibrary
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
     id 'java-library'
     id 'checkstyle'
     id 'jacoco'
     id "com.github.spotbugs" version "6.1.11"
-    id 'maven-publish'
-    id 'signing'
-    id "io.codearte.nexus-staging" version "0.30.0"
     id 'com.adarshr.test-logger' version '4.0.0'
     id "com.github.ben-manes.versions" version "0.52.0"
     id 'org.sonatype.gradle.plugins.scan' version '3.1.1'
     id "org.sonarqube" version "6.1.0.5360"
+    id 'com.vanniktech.maven.publish' version '0.31.0'
 }
 
 group = 'com.imsweb'
-version = '5.7'
+version = '5.8-SNAPSHOT'
 description = 'Java client library for SEER*API'
-
-tasks.withType(JavaCompile).configureEach {
-    options.encoding = 'UTF-8'
-    options.compilerArgs << "-Werror" << "-Xlint:-options"
-}
 
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
-
-    withJavadocJar()
-    withSourcesJar()
 }
 
 repositories {
@@ -38,8 +32,6 @@ dependencies {
 
     api 'com.squareup.retrofit2:retrofit:2.11.0'
     api 'com.squareup.retrofit2:converter-jackson:2.11.0'
-
-    // retrofit will not update these dependencies to fix vulnerabilities
     api 'com.squareup.okhttp3:okhttp:4.12.0'
     api 'com.squareup.okio:okio:3.11.0'
 
@@ -54,11 +46,10 @@ dependencies {
 }
 
 jar {
-    // specify the archive name; otherwise the version is appended to the war file
     archiveFileName = 'seerapi-java.jar'
-
     manifest {
-        attributes('Implementation-Title': 'SEER*API Java Client',
+        attributes(
+                'Implementation-Title': 'SEER*API Java Client',
                 'Implementation-Version': archiveVersion,
                 'Implementation-Vendor': group,
                 'Created-By': System.properties['java.vm.version'] + " (" + System.properties['java.vm.vendor'] + ")",
@@ -70,6 +61,11 @@ jar {
     }
 }
 
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8'
+    options.compilerArgs << "-Werror" << "-Xlint:-options"
+}
+
 tasks.withType(Javadoc).configureEach {
     failOnError false
     options.addStringOption('Xdoclint:none', '-quiet')
@@ -77,25 +73,32 @@ tasks.withType(Javadoc).configureEach {
     options.addStringOption('charSet', 'UTF-8')
 }
 
+javadoc {
+    if (JavaVersion.current().isJava9Compatible()) {
+        options.addBooleanOption('html5', true)
+    }
+}
+
 test {
     useJUnitPlatform()
 }
 
-checkstyle {
-    toolVersion '8.29'
-    configFile = file("config/checkstyle/checkstyle.xml")
-}
-
-spotbugs {
-    excludeFilter = file('config/spotbugs/spotbugs-exclude.xml')
-}
+test.finalizedBy jacocoTestReport
 
 jacocoTestReport {
     reports {
         xml.required = true
     }
 }
-test.finalizedBy jacocoTestReport
+
+checkstyle {
+    toolVersion = '8.29'
+    configFile = file("config/checkstyle/checkstyle.xml")
+}
+
+spotbugs {
+    excludeFilter = file('config/spotbugs/spotbugs-exclude.xml')
+}
 
 sonarqube {
     properties {
@@ -105,115 +108,51 @@ sonarqube {
     }
 }
 
-// Nexus vulnerability scan (see https://github.com/sonatype-nexus-community/scan-gradle-plugin)
 ossIndexAudit {
     outputFormat = 'DEPENDENCY_GRAPH'
     printBanner = false
 }
 
-def isNonStable = { String version ->
-    def stableKeyword = ['RELEASE', 'FINAL', 'GA'].any { it -> version.toUpperCase().contains(it) }
-    def regex = /^[0-9,.v-]+(-r)?$/
-    return !stableKeyword && !(version ==~ regex)
-}
+mavenPublishing {
+    configure(new JavaLibrary(new JavadocJar.Javadoc(), true))
 
-// https://github.com/ben-manes/gradle-versions-plugin
-tasks.named("dependencyUpdates").configure {
-    rejectVersionIf {
-        isNonStable(it.candidate.version)
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, true)
+    signAllPublications()
+
+    pom {
+        name = 'SEER*API Java Client'
+        description = 'API mapping for SEER*API in Java'
+        url = 'https://github.com/imsweb/seerapi-client-java'
+
+        licenses {
+            license {
+                name = 'The MIT License (MIT)'
+                url = 'http://www.opensource.org/licenses/mit-license.php'
+            }
+        }
+
+        developers {
+            developer {
+                id = 'ctmay4'
+                name = 'Chuck May'
+                email = 'mayc@imsweb.com'
+            }
+            developer {
+                id = 'depryf'
+                name = 'Fabian Depry'
+                email = 'depryf@imsweb.com'
+            }
+        }
+
+        scm {
+            url = 'https://github.com/imsweb/seerapi-client-java'
+            connection = 'scm:https://github.com/imsweb/seerapi-client-java.git'
+            developerConnection = 'scm:git@github.com:imsweb/seerapi-client-java.git'
+        }
     }
 }
 
 wrapper {
     gradleVersion = '8.14'
     distributionType = Wrapper.DistributionType.ALL
-}
-
-// don't try to release a snapshot to a non-snapshot repository, that won't work anyway
-if (version.endsWith('-SNAPSHOT')) {
-    gradle.startParameter.excludedTaskNames += 'signMavenJavaPublication'
-    gradle.startParameter.excludedTaskNames += 'closeAndReleaseRepository'
-}
-
-publishing {
-    publications {
-        mavenJava(MavenPublication) {
-            artifactId = 'seerapi-client-java'
-            from components.java
-            versionMapping {
-                usage('java-api') {
-                    fromResolutionOf('runtimeClasspath')
-                }
-                usage('java-runtime') {
-                    fromResolutionResult()
-                }
-            }
-            pom {
-                name = 'SEER*API Java Client'
-                description = 'API mapping for SEER*API in Java'
-                url = 'https://github.com/imsweb/seerapi-client-java'
-                inceptionYear = '2014'
-
-                licenses {
-                    license {
-                        name = 'The MIT License (MIT)'
-                        url = 'http://www.opensource.org/licenses/mit-license.php'
-                        distribution = 'repo'
-                    }
-                }
-
-                developers {
-                    developer {
-                        id = 'ctmay4'
-                        name = 'Chuck May'
-                        email = 'mayc@imsweb.com'
-                    }
-                    developer {
-                        id = 'depryf'
-                        name = 'Fabian Depry'
-                        email = 'depryf@imsweb.com'
-                    }
-                }
-
-                scm {
-                    url = 'https://github.com/imsweb/seerapi-client-java'
-                    connection = 'scm:https://github.com/imsweb/seerapi-client-java.git'
-                    developerConnection = 'scm:git@github.com:imsweb/seerapi-client-java.git'
-                }
-            }
-        }
-    }
-    repositories {
-        maven {
-            def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2"
-            def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots"
-            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
-
-            credentials {
-                username = project.findProperty('nexusUsername') ?: ''
-                password = project.findProperty('nexusPassword') ?: ''
-            }
-        }
-    }
-}
-
-signing {
-    def signingKey = project.findProperty('signingKey') ?: ''
-    def signingPassword = project.findProperty('signingPassword') ?: ''
-
-    useInMemoryPgpKeys(signingKey, signingPassword)
-
-    sign publishing.publications.mavenJava
-}
-
-javadoc {
-    if (JavaVersion.current().isJava9Compatible()) {
-        options.addBooleanOption('html5', true)
-    }
-}
-
-// configure nexus staging plugin
-nexusStaging {
-    numberOfRetries = 50
-    delayBetweenRetriesInMillis = 5000
 }


### PR DESCRIPTION
Maven Central is deprecating the method we used to release artifacts. All namespaces need to be migrated to the Central Portal. See https://central.sonatype.org/faq/what-is-different-between-central-portal-and-legacy-ossrh/ for details.